### PR TITLE
KOTH V1.0.0 Feature/koth tip

### DIFF
--- a/Horizon.Plugin.UYA/CustomModes/KothCustomMode.cs
+++ b/Horizon.Plugin.UYA/CustomModes/KothCustomMode.cs
@@ -1,0 +1,29 @@
+using Server.Medius.Models;
+using Server.Medius.PluginArgs;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Horizon.Plugin.UYA.CustomModes
+{
+    public class KothCustomMode : BaseCustomMode
+    {
+        public override CustomModeId Id => CustomModeId.CMODE_ID_KOTH;
+        public override string Name => "King of the Hill";
+
+        public override Task OnClientPostWideStats(OnPlayerWideStatsArgs args)
+        {
+            // accept stats
+            return Task.CompletedTask;
+        }
+
+        public override Task<Payload> GetPayload(Server.Medius.Models.Game game, ClientObject client, GameMetadata metadata)
+        {
+            var dataPath = Path.Combine(Plugin.WorkingDirectory, $"bin/patch/koth-{client.ApplicationId}.bin");
+            if (File.Exists(dataPath))
+                return Task.FromResult(new Payload(0x000fa000, File.ReadAllBytes(dataPath)));
+
+            // binary not found for game mode
+            return Task.FromResult<Payload>(null);
+        }
+    }
+}

--- a/Horizon.Plugin.UYA/CustomModes/KothCustomMode.cs
+++ b/Horizon.Plugin.UYA/CustomModes/KothCustomMode.cs
@@ -20,7 +20,7 @@ namespace Horizon.Plugin.UYA.CustomModes
         {
             var dataPath = Path.Combine(Plugin.WorkingDirectory, $"bin/patch/koth-{client.ApplicationId}.bin");
             if (File.Exists(dataPath))
-                return Task.FromResult(new Payload(0x000fa000, File.ReadAllBytes(dataPath)));
+                return Task.FromResult(new Payload(Regions.CUSTOM_GAME_MODE, File.ReadAllBytes(dataPath)));
 
             // binary not found for game mode
             return Task.FromResult<Payload>(null);

--- a/Horizon.Plugin.UYA/Game.cs
+++ b/Horizon.Plugin.UYA/Game.cs
@@ -599,6 +599,8 @@ namespace Horizon.Plugin.UYA
         public bool grSiegeNoTies { get; set; }
         public byte grKothScoreLimit { get; set; }
         public byte grKothHillDuration { get; set; }
+        public byte grKothRespawnOutside { get; set; }
+        public byte grKothRespawnInside { get; set; }
         public int grSeed { get; set; }
         public bool grNewPlayerSync { get; set; }
         public bool prSurvivor { get; set; }
@@ -609,7 +611,7 @@ namespace Horizon.Plugin.UYA
 
         public byte[] Serialize()
         {
-            byte[] output = new byte[44];
+            byte[] output = new byte[46];
             using (var ms = new MemoryStream(output, true))
             {
                 using (var writer = new MessageWriter(ms))
@@ -648,6 +650,8 @@ namespace Horizon.Plugin.UYA
                     writer.Write(grSiegeNoTies);
                     writer.Write(grKothScoreLimit);
                     writer.Write(grKothHillDuration);
+                    writer.Write(grKothRespawnOutside);
+                    writer.Write(grKothRespawnInside);
                     writer.Write(grSeed);
                     writer.Write(grNewPlayerSync);
                     writer.Write(prSurvivor);
@@ -697,6 +701,8 @@ namespace Horizon.Plugin.UYA
             grSiegeNoTies = reader.ReadBoolean();
             grKothScoreLimit = reader.ReadByte();
             grKothHillDuration = reader.ReadByte();
+            grKothRespawnOutside = reader.ReadByte();
+            grKothRespawnInside = reader.ReadByte();
             grSeed = reader.ReadInt32();
             grNewPlayerSync = reader.ReadBoolean();
             prSurvivor = reader.ReadBoolean();
@@ -742,6 +748,8 @@ namespace Horizon.Plugin.UYA
                 && grSiegeNoTies == other.grSiegeNoTies
                 && grKothScoreLimit == other.grKothScoreLimit
                 && grKothHillDuration == other.grKothHillDuration
+                && grKothRespawnOutside == other.grKothRespawnOutside
+                && grKothRespawnInside == other.grKothRespawnInside
                 && grSeed == other.grSeed
                 && grNewPlayerSync == other.grNewPlayerSync
                 && prSurvivor == other.prSurvivor

--- a/Horizon.Plugin.UYA/Game.cs
+++ b/Horizon.Plugin.UYA/Game.cs
@@ -597,6 +597,9 @@ namespace Horizon.Plugin.UYA
         public byte grAllNodesTimer { get; set; }
         public byte grNodeSelectTimer { get; set; }
         public bool grSiegeNoTies { get; set; }
+        public byte grKothScoreLimit { get; set; }
+        public byte grKothHillDuration { get; set; }
+        public int grSeed { get; set; }
         public bool grNewPlayerSync { get; set; }
         public bool prSurvivor { get; set; }
         public bool prChargebootForever { get; set; }
@@ -606,7 +609,7 @@ namespace Horizon.Plugin.UYA
 
         public byte[] Serialize()
         {
-            byte[] output = new byte[38];
+            byte[] output = new byte[44];
             using (var ms = new MemoryStream(output, true))
             {
                 using (var writer = new MessageWriter(ms))
@@ -643,6 +646,9 @@ namespace Horizon.Plugin.UYA
                     writer.Write(grAllNodesTimer);
                     writer.Write(grNodeSelectTimer);
                     writer.Write(grSiegeNoTies);
+                    writer.Write(grKothScoreLimit);
+                    writer.Write(grKothHillDuration);
+                    writer.Write(grSeed);
                     writer.Write(grNewPlayerSync);
                     writer.Write(prSurvivor);
                     writer.Write(prChargebootForever);
@@ -689,6 +695,9 @@ namespace Horizon.Plugin.UYA
             grAllNodesTimer = reader.ReadByte();
             grNodeSelectTimer = reader.ReadByte();
             grSiegeNoTies = reader.ReadBoolean();
+            grKothScoreLimit = reader.ReadByte();
+            grKothHillDuration = reader.ReadByte();
+            grSeed = reader.ReadInt32();
             grNewPlayerSync = reader.ReadBoolean();
             prSurvivor = reader.ReadBoolean();
             prChargebootForever = reader.ReadBoolean();
@@ -731,6 +740,9 @@ namespace Horizon.Plugin.UYA
                 && grAllNodesTimer == other.grAllNodesTimer
                 && grNodeSelectTimer == other.grNodeSelectTimer
                 && grSiegeNoTies == other.grSiegeNoTies
+                && grKothScoreLimit == other.grKothScoreLimit
+                && grKothHillDuration == other.grKothHillDuration
+                && grSeed == other.grSeed
                 && grNewPlayerSync == other.grNewPlayerSync
                 && prSurvivor == other.prSurvivor
                 && prChargebootForever == other.prChargebootForever

--- a/Horizon.Plugin.UYA/Game.cs
+++ b/Horizon.Plugin.UYA/Game.cs
@@ -601,6 +601,8 @@ namespace Horizon.Plugin.UYA
         public byte grKothHillDuration { get; set; }
         public byte grKothRespawnOutside { get; set; }
         public byte grKothRespawnInside { get; set; }
+        public byte grKothHillSizeIdx { get; set; }
+        public bool grKothContestedStopsScore { get; set; }
         public int grSeed { get; set; }
         public bool grNewPlayerSync { get; set; }
         public bool prSurvivor { get; set; }
@@ -611,7 +613,7 @@ namespace Horizon.Plugin.UYA
 
         public byte[] Serialize()
         {
-            byte[] output = new byte[46];
+            byte[] output = new byte[48];
             using (var ms = new MemoryStream(output, true))
             {
                 using (var writer = new MessageWriter(ms))
@@ -652,6 +654,8 @@ namespace Horizon.Plugin.UYA
                     writer.Write(grKothHillDuration);
                     writer.Write(grKothRespawnOutside);
                     writer.Write(grKothRespawnInside);
+                    writer.Write(grKothHillSizeIdx);
+                    writer.Write(grKothContestedStopsScore);
                     writer.Write(grSeed);
                     writer.Write(grNewPlayerSync);
                     writer.Write(prSurvivor);
@@ -703,6 +707,8 @@ namespace Horizon.Plugin.UYA
             grKothHillDuration = reader.ReadByte();
             grKothRespawnOutside = reader.ReadByte();
             grKothRespawnInside = reader.ReadByte();
+            grKothHillSizeIdx = reader.ReadByte();
+            grKothContestedStopsScore = reader.ReadBoolean();
             grSeed = reader.ReadInt32();
             grNewPlayerSync = reader.ReadBoolean();
             prSurvivor = reader.ReadBoolean();
@@ -750,6 +756,8 @@ namespace Horizon.Plugin.UYA
                 && grKothHillDuration == other.grKothHillDuration
                 && grKothRespawnOutside == other.grKothRespawnOutside
                 && grKothRespawnInside == other.grKothRespawnInside
+                && grKothHillSizeIdx == other.grKothHillSizeIdx
+                && grKothContestedStopsScore == other.grKothContestedStopsScore
                 && grSeed == other.grSeed
                 && grNewPlayerSync == other.grNewPlayerSync
                 && prSurvivor == other.prSurvivor

--- a/Horizon.Plugin.UYA/Modes.cs
+++ b/Horizon.Plugin.UYA/Modes.cs
@@ -14,7 +14,8 @@ namespace Horizon.Plugin.UYA
             new InfectedCustomMode(),
             new JuggernaughtCustomMode(),
             new MidFlagCustomMode(),
-            new DominationCustomMode()
+            new DominationCustomMode(),
+            new KothCustomMode()
         };
 
         public static BaseCustomMode FindCustomModeById(CustomModeId id)
@@ -31,6 +32,7 @@ namespace Horizon.Plugin.UYA
         CMODE_ID_INFECTED = 2,
         CMODE_ID_JUGGERNAUGHT = 3,
         CMODE_ID_DOMINATION = 4,
+        CMODE_ID_KOTH = 5,
 
         // reserved for custom maps
         CMODE_ID_SPLEEF = -1,


### PR DESCRIPTION
KOTH 
  - Game config serialization expanded to carry respawn distance choices (inside/outside), hill size index, and contested-scoring toggle; buffer size bumped and equality/serialize/deserialize updated accordingly
    --(Horizon.Plugin.UYA/Game.cs)
- Custom game mode payloads now use centralized region constants for module definitions and custom binaries; all modes (Domination, Infected, Juggernaught, KOTH, MidFlag, Spleef) load via Regions. CUSTOM_GAME_MODE, and module entries in Game.cs target Regions. 
  - MODULE_DEFINITIONS instead of raw addresses.
  - Patch delivery switched to shared Regions offsets: payloads, unpatch, exception handler, patch config, and hash all reference typed constants; patch hash query now reads from Regions.PATCH_HASH 
   -- (Horizon.Plugin.UYA/ Patch.cs, Horizon.Plugin.UYA/Regions.cs).
